### PR TITLE
Ignore debug plugins included in Quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Debug plugins
+plugins/log-deprecated-notices
+plugins/monster-widget
+plugins/query-monitor
+plugins/user-switching


### PR DESCRIPTION
Ignores the debug plugins added by Quickstart (see https://github.com/Automattic/vip-go-quickstart/commit/82208ade49621da7a85f40e7ba43bd79930c8e70)