### PR TITLE
Add .gitkeep to required directories.

### DIFF
--- a/plugins/.gitkeep
+++ b/plugins/.gitkeep
@@ -1,0 +1,1 @@
+# Important: This directory cannot be empty.

--- a/themes/.gitkeep
+++ b/themes/.gitkeep
@@ -1,0 +1,1 @@
+# Important: This directory cannot be empty.

--- a/vip-config/.gitkeep
+++ b/vip-config/.gitkeep
@@ -1,0 +1,1 @@
+# Important: This directory cannot be empty.


### PR DESCRIPTION
VIP Go repositories are invalid if they don't contain the themes,
plugins, and vip-config directories.